### PR TITLE
Remove unnecessary angle brackets

### DIFF
--- a/roles/ispmail-dovecot/templates/10-ssl.conf
+++ b/roles/ispmail-dovecot/templates/10-ssl.conf
@@ -10,8 +10,8 @@ ssl = required
 # dropping root privileges, so keep the key file unreadable by anyone but
 # root. Included doc/mkcert.sh can be used to easily generate self-signed
 # certificate, just make sure to update the domains in dovecot-openssl.cnf
-ssl_cert = <{{tls_cert}}
-ssl_key = <{{tls_key}}
+ssl_cert = {{tls_cert}}
+ssl_key = {{tls_key}}
 
 # When using Let's Encrypt use these lines instead:
 # ssl_cert = </etc/letsencrypt/live/webmail.example.org/fullchain.pem
@@ -52,7 +52,7 @@ ssl_client_ca_dir = /etc/ssl/certs
 # Generate new params with `openssl dhparam -out /etc/dovecot/dh.pem 4096`
 # Or migrate from old ssl-parameters.dat file with the command dovecot
 # gives on startup when ssl_dh is unset.
-ssl_dh = </usr/share/dovecot/dh.pem
+ssl_dh = /usr/share/dovecot/dh.pem
 
 # Minimum SSL protocol version to use. Potentially recognized values are SSLv3,
 # TLSv1, TLSv1.1, and TLSv1.2, depending on the OpenSSL version used.


### PR DESCRIPTION
These unnecessary angle brackets break the dovecot configuration and need to be removed from the template.